### PR TITLE
Add the 'No Death' cheat code and app does not use non-exempt encryption

### DIFF
--- a/Snake.sdl/Snake.sdl/Info-Framework.plist
+++ b/Snake.sdl/Snake.sdl/Info-Framework.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>

--- a/Snake.sdl/Snake.sdl/game.c
+++ b/Snake.sdl/Snake.sdl/game.c
@@ -8,6 +8,7 @@
 
 struct _Game {
   enum GAME_MODES mode;
+  enum CHEAT_CODES enabled_cheat_codes;
 
   Coordinates** screen;
 
@@ -302,4 +303,14 @@ destroy_game(Game* game) {
 
   destroy_snake(game->snake);
   game->snake = NULL;
+}
+
+void
+set_cheat_codes(Game* game, enum CHEAT_CODES cheat_codes) {
+  game->enabled_cheat_codes ^= cheat_codes;
+}
+
+bool
+no_death(Game* game) {
+  return (game->enabled_cheat_codes & NO_DEATH) > 0;
 }

--- a/Snake.sdl/Snake.sdl/game.h
+++ b/Snake.sdl/Snake.sdl/game.h
@@ -34,6 +34,8 @@ Coordinates* get_bottom_right_corner(Game* game);
 Coordinates* get_screen_coordinate(Game* game, size_t index);
 enum GAME_MODES get_game_mode(Game* game);
 void set_game_mode(Game* game, enum GAME_MODES mode);
+void set_cheat_codes(Game* game, enum CHEAT_CODES cheat_codes);
+bool no_death(Game* game);
 
 void destroy_game(Game* game);
 #endif // SNAKE_SDL_SNAKE_SDL_GAME_H_

--- a/Snake.sdl/Snake.sdl/main.c
+++ b/Snake.sdl/Snake.sdl/main.c
@@ -131,6 +131,12 @@ SDL_AppEvent(void* appstate, SDL_Event* event) {
 
           break;
       }
+
+      // Cheat Codes
+      switch (key) {
+        case SDLK_D: set_cheat_codes(game, NO_DEATH); break;
+        default: break;
+      }
     }
   }
 
@@ -210,7 +216,10 @@ SDL_AppIterate(void* appstate) {
 
   if (is_there_a_collision) {
     set_current_movement(game, NOTHING);
-    set_game_mode(game, QUIT);
+
+    if (!no_death(game)) {
+      set_game_mode(game, QUIT);
+    }
   }
 
   bool has_food_been_eaten = has_just_eaten_food(snake, get_food_location(game));

--- a/Snake.sdl/Snake.sdl/snake.c
+++ b/Snake.sdl/Snake.sdl/snake.c
@@ -9,21 +9,6 @@ bool
 has_collided(enum TILE_TYPES tile_type) {
   switch (tile_type) {
     case USED_BY_SNAKE_TAIL: return true;
-    /* case USED_BY_LEFT_BORDER: */
-    /*   #<{(| FALLTHROUGH |)}># */
-    /* case USED_BY_RIGHT_BORDER: */
-    /*   #<{(| FALLTHROUGH |)}># */
-    /* case USED_BY_TOP_BORDER: */
-    /*   #<{(| FALLTHROUGH |)}># */
-    /* case USED_BY_BOTTOM_BORDER: */
-    /*   #<{(| FALLTHROUGH |)}># */
-    /* case USED_BY_TOP_LEFT_BORDER: */
-    /*   #<{(| FALLTHROUGH |)}># */
-    /* case USED_BY_TOP_RIGHT_BORDER: */
-    /*   #<{(| FALLTHROUGH |)}># */
-    /* case USED_BY_BOTTOM_LEFT_BORDER: */
-    /*   #<{(| FALLTHROUGH |)}># */
-    /* case USED_BY_BOTTOM_RIGHT_BORDER: return true; */
     default: return false;
   };
 }

--- a/Snake.sdl/Snake.sdl/types.h
+++ b/Snake.sdl/Snake.sdl/types.h
@@ -5,6 +5,11 @@
 
 enum MOVEMENTS { NOTHING, LEFT, UP, RIGHT, DOWN };
 
+enum CHEAT_CODES {
+  NONE = 0b0,
+  NO_DEATH = 0b1,
+};
+
 enum TILE_TYPES {
   AVAILABLE = 0b0,
   USED_BY_FOOD = 0b1,


### PR DESCRIPTION
# No Death

## Description

1. Press `D` to toggle "No Death".
2. Do not use "non-exempt" encryption.
3. Cleaned the code.
